### PR TITLE
feat(k-receipt-config): create admin config k-receipt deduction API

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,6 +15,59 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin/deductions/k-receipt": {
+            "post": {
+                "description": "To setting k-receipt deduction amount for use in tax calculate",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "deduction"
+                ],
+                "summary": "K-Receipt Deduction Config API",
+                "parameters": [
+                    {
+                        "description": "new amount that you want to set",
+                        "name": "tax",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/DeductionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/kReceiptResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "validate error or cannot get body",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "data not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/deductions/personal": {
             "post": {
                 "description": "To setting personal deduction amount for use in tax calculate",
@@ -272,6 +325,14 @@ const docTemplate = `{
                     }
                 },
                 "taxRefund": {
+                    "type": "number"
+                }
+            }
+        },
+        "kReceiptResponse": {
+            "type": "object",
+            "properties": {
+                "kReceipt": {
                     "type": "number"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -8,6 +8,59 @@
     },
     "host": "localhost:8080",
     "paths": {
+        "/admin/deductions/k-receipt": {
+            "post": {
+                "description": "To setting k-receipt deduction amount for use in tax calculate",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "deduction"
+                ],
+                "summary": "K-Receipt Deduction Config API",
+                "parameters": [
+                    {
+                        "description": "new amount that you want to set",
+                        "name": "tax",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/DeductionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/kReceiptResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "validate error or cannot get body",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "data not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/deductions/personal": {
             "post": {
                 "description": "To setting personal deduction amount for use in tax calculate",
@@ -265,6 +318,14 @@
                     }
                 },
                 "taxRefund": {
+                    "type": "number"
+                }
+            }
+        },
+        "kReceiptResponse": {
+            "type": "object",
+            "properties": {
+                "kReceipt": {
                     "type": "number"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -75,6 +75,11 @@ definitions:
       taxRefund:
         type: number
     type: object
+  kReceiptResponse:
+    properties:
+      kReceipt:
+        type: number
+    type: object
 host: localhost:8080
 info:
   contact: {}
@@ -82,6 +87,41 @@ info:
   title: K-Tax API
   version: "1.0"
 paths:
+  /admin/deductions/k-receipt:
+    post:
+      consumes:
+      - application/json
+      description: To setting k-receipt deduction amount for use in tax calculate
+      parameters:
+      - description: new amount that you want to set
+        in: body
+        name: tax
+        required: true
+        schema:
+          $ref: '#/definitions/DeductionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/kReceiptResponse'
+        "400":
+          description: validate error or cannot get body
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: data not found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "500":
+          description: internal server error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: K-Receipt Deduction Config API
+      tags:
+      - admin
+      - deduction
   /admin/deductions/personal:
     post:
       consumes:

--- a/handlers/admin.go
+++ b/handlers/admin.go
@@ -15,7 +15,7 @@ type AdminHandlers struct {
 
 type AdminServicer interface {
 	ValidateDeductionRequest(slug string, amount float64) error
-	UpdateDeductionConfig(deduction models.DeductionRequest) (models.Deduction, error)
+	UpdateDeductionConfig(slug string, deduction models.DeductionRequest) (models.Deduction, error)
 }
 
 func NewAdminHandlers(service AdminServicer) *AdminHandlers {
@@ -47,7 +47,7 @@ func (h *AdminHandlers) PersonalDeductionConfigHandler(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, models.ErrorResponse{Message: err.Error()})
 	}
 
-	deduction, err := h.Service.UpdateDeductionConfig(*body)
+	deduction, err := h.Service.UpdateDeductionConfig(models.PersonalSlug, *body)
 
 	if err != nil {
 		c.Logger().Error(err)
@@ -57,6 +57,46 @@ func (h *AdminHandlers) PersonalDeductionConfigHandler(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, models.ErrorResponse{Message: utils.ErrInternalServer.Error()})
 	}
 	result := models.PersonalResponse{
+		Amount: deduction.Amount,
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+// KReceiptDeductionConfigHandler
+//
+// @Summary K-Receipt Deduction Config API
+// @Description To setting k-receipt deduction amount for use in tax calculate
+// @Tags admin, deduction
+// @Accept json
+// @Produce json
+// @securityDefinitions.basic BasicAuth
+// @Param tax body DeductionRequest true "new amount that you want to set"
+// @Success 200 {object} kReceiptResponse
+// @Router /admin/deductions/k-receipt [post]
+// @Failure 404 {object} ErrorResponse "data not found"
+// @Failure 400 {object} ErrorResponse "validate error or cannot get body"
+// @Failure 500 {object} ErrorResponse "internal server error"
+func (h *AdminHandlers) KReceiptDeductionConfigHandler(c echo.Context) error {
+	body := new(models.DeductionRequest)
+	if err := c.Bind(body); err != nil {
+		return c.JSON(http.StatusBadRequest, models.ErrorResponse{Message: err.Error()})
+	}
+
+	if err := h.Service.ValidateDeductionRequest(models.KReceiptSlug, body.Amount); err != nil {
+		c.Logger().Error(err)
+		return c.JSON(http.StatusBadRequest, models.ErrorResponse{Message: err.Error()})
+	}
+
+	deduction, err := h.Service.UpdateDeductionConfig(models.KReceiptSlug, *body)
+
+	if err != nil {
+		c.Logger().Error(err)
+		if err == sql.ErrNoRows {
+			return c.JSON(http.StatusNotFound, models.ErrorResponse{Message: "data not found"})
+		}
+		return c.JSON(http.StatusInternalServerError, models.ErrorResponse{Message: utils.ErrInternalServer.Error()})
+	}
+	result := models.KReceiptResponse{
 		Amount: deduction.Amount,
 	}
 	return c.JSON(http.StatusOK, result)

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 	groupAdmin := e.Group("/admin")
 	groupAdmin.Use(middlewares.BasicAuthMiddleware())
 	groupAdmin.POST("/deductions/personal", adminHandler.PersonalDeductionConfigHandler)
+	groupAdmin.POST("/deductions/k-receipt", adminHandler.KReceiptDeductionConfigHandler)
 
 	// make graceful shutdown
 	shutdownCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt)

--- a/models/admin.go
+++ b/models/admin.go
@@ -7,3 +7,7 @@ type DeductionRequest struct {
 type PersonalResponse struct {
 	Amount float64 `json:"personalDeduction"`
 } //@Name PersonalResponse
+
+type KReceiptResponse struct {
+	Amount float64 `json:"kReceipt"`
+} //@Name kReceiptResponse

--- a/services/admin.go
+++ b/services/admin.go
@@ -27,13 +27,13 @@ func NewAdminService(db AdminStorer) *AdminService {
 	}
 }
 
-func (as *AdminService) UpdateDeductionConfig(amount models.DeductionRequest) (response models.Deduction, err error) {
-	err = as.ValidateDeductionRequest(models.PersonalSlug, amount.Amount)
+func (as *AdminService) UpdateDeductionConfig(slug string, amount models.DeductionRequest) (response models.Deduction, err error) {
+	err = as.ValidateDeductionRequest(slug, amount.Amount)
 	if err != nil {
 		return
 	}
 
-	response, err = as.Db.UpdateDeduction(models.PersonalSlug, amount.Amount)
+	response, err = as.Db.UpdateDeduction(slug, amount.Amount)
 	return
 }
 

--- a/services/admin_test.go
+++ b/services/admin_test.go
@@ -227,7 +227,7 @@ func TestUpdateDeductionConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			service := setupAdminService(tc.stub)
 
-			result, err := service.UpdateDeductionConfig(tc.params)
+			result, err := service.UpdateDeductionConfig("test", tc.params)
 
 			// verify get deduction was called
 			tc.stub.assertMethodWasCalled(t, "GetDeduction")


### PR DESCRIPTION
changelog
1. change adminService.UpdateDeductionConfig params from 1 to 2 with slug and amount
2. change fix slug in adminService.UpdateDeductionConfig to dynamic from parameter
3. update swagger to support admin k-receipt deduction config API
4. add admin API for k-receipt deduction config

------------------
HTTP Method: POST
URL: "/admin/deductions/k-receipt"
Content-Type: "application/json"
Authorization: "Basic Authentication"
Body:
`{
    "amount": 70000
}`

Response
`{
    "kReceipt": 70000
}`
-----------------